### PR TITLE
Force app data 'text' to be a string

### DIFF
--- a/custom_components/awtrix_notification/awtrix.py
+++ b/custom_components/awtrix_notification/awtrix.py
@@ -53,6 +53,9 @@ class AwtrixTime:
                     if icon:
                         msg["icon"] = icon
 
+            if 'text' in msg:
+                msg['text'] = str(msg['text'])
+
             payload = json.dumps(msg) if len(msg) else ""
             service_data = {"payload": payload,
                             "topic": topic}


### PR DESCRIPTION
json.dumps will assume a float or integer is a number causing awtrix to break - so we cast msg.text to a string to make sure it's a string