### PR TITLE
Force app data 'text' to be a string only if integer or float

### DIFF
--- a/custom_components/awtrix_notification/awtrix.py
+++ b/custom_components/awtrix_notification/awtrix.py
@@ -54,7 +54,7 @@ class AwtrixTime:
                         msg["icon"] = icon
 
             if 'text' in msg:
-                if isinstance((msg['text']), int) or isinstance((msg['text']), float):
+                if isinstance(msg['text'], (int, float)):
                     msg['text'] = str(msg['text'])
                 else:
                     msg['text']

--- a/custom_components/awtrix_notification/awtrix.py
+++ b/custom_components/awtrix_notification/awtrix.py
@@ -54,7 +54,10 @@ class AwtrixTime:
                         msg["icon"] = icon
 
             if 'text' in msg:
-                msg['text'] = str(msg['text'])
+                if isinstance((msg['text']), int) or isinstance((msg['text']), float):
+                    msg['text'] = str(msg['text'])
+                else:
+                    msg['text']
 
             payload = json.dumps(msg) if len(msg) else ""
             service_data = {"payload": payload,


### PR DESCRIPTION
Update from @daath (#11) broke functionality for segmented colors in the text (https://blueforcer.github.io/awtrix3/#/api?id=display-text-in-colored-fragments)

I have very little python experience but I think this change seems to fix that by only forcing it to be a string if the original text is an integer or float.

Tested on my system and seems to work.